### PR TITLE
Fixup environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: cookbook-dev
 channels:
-  - pytorch
   - conda-forge
 dependencies:
   - jupyterlab
@@ -10,16 +9,5 @@ dependencies:
   - xarray
   - intake
   - matplotlib
-  - IPython
-  - pytorch
+  - pytorch-cpu
   - xbatcher
-  - sphinx
-  - sphinxcontrib-applehelp
-  - sphinxcontrib-devhelp
-  - sphinxcontrib-htmlhelp
-  - sphinxcontrib-qthelp
-  - sphinxcontrib-serializinghtml
-  - pydata-sphinx-theme
-  - jsonschema-with-format-nongpl
-  - docutils
-  - sphinx-pythia-theme


### PR DESCRIPTION
A few changes I _think_ will drastically speed up your environment generation.

1. Before Pythia "mystified", we had old theme dependencies that fell out of maintenance. These have conflicts with other major python and package versions and can drastically slow down environment generation. You might notice your environment has an older Python version than you expect.
2. PyTorch has [retired support for their official `pytorch` conda channel](https://github.com/pytorch/pytorch/issues/138506). You can find community maintained `pytorch-cpu` and `pytorch-gpu` packages on conda-forge, or you can add the following to install from pip. Here I've opted for conda-forge.
```{yaml}
# from environment.yml
# ...
- xbatcher
- pip
  - torch
```

If you need to install from pip with more complex steps (specific wheels for specific drivers/hardware etc.) you can use `pip install --no-cache-dir torch ...` from within your conda environment. 
